### PR TITLE
Make using alternative BEM notation trivial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+bower_components

--- a/jquery.bem.js
+++ b/jquery.bem.js
@@ -7,17 +7,29 @@
    * @constructor
    */
   function BEM(config) {
+    this.setConfig(config);
+  };
 
-    /**
-     * Default configuration.
-     * @type {Object}
-     */
-    this.config = config || {};
+  /**
+   * Set the config for the plugin
+   * @param {Object} config - defaults in br
+   * @param {String} [config.elemPrefix] - Element prefix (default: '__')
+   * @param {String} [config.modPrefix] - Modifier prefix (default: '_')
+   * @param {String} [config.modDlmtr] - Modifier delimiter (default: '_')
+   * @param {String} [config.namePattern] -
+   *   Pattern to match valid block names (default: '[a-zA-Z0-9-]+')
+   */
+  BEM.prototype.setConfig = function(config) {
+    this.config = $.extend({}, {
+      namePattern: '[a-zA-Z0-9-]+',
+      elemPrefix: '__',
+      modPrefix: '_',
+      modDlmtr: '_'
+    }, config);
 
     this.blockClassRe = this.buildBlockClassRe();
     this.elemClassRe = this.buildElemClassRe();
     this.modClassRe = this.buildModClassRe();
-
   };
 
   /**
@@ -508,18 +520,11 @@
   /**
    * Create BEM instance.
    */
-
-  $.BEM = new BEM({
-    namePattern: '[a-zA-Z0-9-]+',
-    elemPrefix: '__',
-    modPrefix: '_',
-    modDlmtr: '_'
-  });
+  $.BEM = new BEM();
 
   /**
    * Extend jQuery object.
    */
-
   $.fn.extend({
     block: function() {
       return $.BEM.getBlock(this);

--- a/test/jquery.bem.test.js
+++ b/test/jquery.bem.test.js
@@ -1,4 +1,12 @@
-QUnit.module('core');
+QUnit.module('core', {
+
+  /**
+   * Reset the config variables before each test case.
+   */
+  beforeEach: function() {
+    $.BEM.setConfig();
+  }
+});
 
 QUnit.test('get class type', function(assert) {
   assert.ok($.BEM.getClassType('block') == 'block',
@@ -26,6 +34,43 @@ QUnit.test('get class type', function(assert) {
   );
 
   assert.ok($.BEM.getClassType('other-class_unknown_elem__mod') == null,
+    'unknown class detection'
+  );
+});
+
+QUnit.test('overriding config', function(assert) {
+  $.BEM.setConfig({
+    namePattern: '[a-z]+',
+    elemPrefix: '____',
+    modPrefix: '--',
+    modDlmtr: '---'
+  });
+
+  assert.ok($.BEM.getClassType('block') == 'block',
+    'block class detection'
+  );
+
+  assert.ok($.BEM.getClassType('block____elem') == 'elem',
+    'element class detection'
+  );
+
+  assert.ok($.BEM.getClassType('block--key---val') == 'mod',
+    'block modifier class detection'
+  );
+
+  assert.ok($.BEM.getClassType('block____elem--key---val') == 'mod',
+    'element modifier class detection'
+  );
+
+  assert.ok($.BEM.getClassType('block--mod') == 'mod',
+    'boolean block modifier detection'
+  );
+
+  assert.ok($.BEM.getClassType('block____elem--mod') == 'mod',
+    'boolean element modifier detection'
+  );
+
+  assert.ok($.BEM.getClassType('other-class--unknown---elem__mod') == null,
     'unknown class detection'
   );
 });


### PR DESCRIPTION
I wanted to use `--` as the modifier notation rather than `_`,
but found that because this the config was wrapped up in the
constructor it was a little messy to do, and required the regexs
to be recompiled.

Therefore, I've moved the config setting into a separate
`setConfig()` method, which is invoked during initialisation,
but can be overriden by end-users:

```js
$.BEM.setConfig({
  modPrefix: '--',
  modDlmtr: '--'
});
```