### PR TITLE
support ctx param for .elem()

### DIFF
--- a/jquery.bem.js
+++ b/jquery.bem.js
@@ -76,8 +76,8 @@
    */
   BEM.prototype.findElem = function($this, elemKey) {
     var blockClass = this.getBlockClass($this)
-      , elemName = this.buildElemClass(blockClass, elemKey)
-      , elem = $this.find('.' + elemName);
+      , elemSelector = '.' + this.buildElemClass(blockClass, elemKey)
+      , elem = $this.is(elemSelector) ? $this : $this.find(elemSelector);
 
     return elem;
   };
@@ -530,8 +530,13 @@
       return $.BEM.getBlock(this);
     },
 
-    elem: function(elemKey) {
-      return $.BEM.findElem(this, elemKey);
+    elem: function(ctx, elemKey) {
+      if (!elemKey) {
+        elemKey = ctx;
+        delete ctx;
+      }
+
+      return $.BEM.findElem(ctx || this, elemKey);
     },
 
     ctx: function(block, elem) {


### PR DESCRIPTION
Hi,
now we can find elements on specified context  ``block.elem($(e.target), 'item');``
=)